### PR TITLE
Octo Balancing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1174,7 +1174,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1195,12 +1196,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1215,17 +1218,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1342,7 +1348,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1354,6 +1361,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1368,6 +1376,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1375,12 +1384,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1399,6 +1410,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1479,7 +1491,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1491,6 +1504,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1576,7 +1590,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1612,6 +1627,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1631,6 +1647,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1674,12 +1691,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ async function matchOcto(typeToMatch : number, originalMessage: any) {
         // Check that it hasn't already been matched (by a user)
         if(!octoArray.every(inst => inst.id !== idOfOriginalMessage)) {
             //Remove the message from the array
-            octoArray.splice(octoArray.findIndex(inst => inst.id == idOfOriginalMessage), 1);
+            octoArray.splice(octoArray.findIndex(inst => inst.id === idOfOriginalMessage), 1);
             //Send message to match the octopus.
             if(typeToMatch == 1) {
                 originalMessage.channel.send(`<:Octo2:624238818807119882>`);
@@ -214,11 +214,13 @@ syrene.on('message', async (msg: Discord.Message) => {
     // Use strict equality since we really only want to consider the message body being strictly the emoji.
       await octoMutex.lock();
       try {
-          if(octoArray.length !== 0 && octoArray[octoArray.length - 1].type === 2) {
+          let thisChannelOctos = octoArray.filter(inst => inst.chan_id === msg.channel.id);
+          if(thisChannelOctos.length !== 0 && thisChannelOctos[thisChannelOctos.length - 1].type === 2) {
               //This message is here to match an Octo2; just cancel it out
-              octoArray.pop();
+              let cancelledOutMsg = thisChannelOctos[thisChannelOctos.length - 1].id;
+              octoArray.splice(octoArray.findIndex(inst => inst.id === cancelledOutMsg), 1);
           } else {
-            octoArray.push({type: 1, id: msg.id}); //Remember this message
+            octoArray.push({type: 1, id: msg.id, chan_id: msg.channel.id}); //Remember this message
             setTimeout(matchOcto, octoTimeout, 1, msg); //Match it later.
           }
       } finally { octoMutex.release(); }
@@ -227,10 +229,12 @@ syrene.on('message', async (msg: Discord.Message) => {
       //Could potentially abstract it out but probs not worth it
       await octoMutex.lock();
       try {
-          if(octoArray.length !== 0 && octoArray[octoArray.length - 1].type === 1) {
-              octoArray.pop();
+          let thisChannelOctos = octoArray.filter(inst => inst.chan_id === msg.channel.id);
+          if(thisChannelOctos.length !== 0 && thisChannelOctos[thisChannelOctos.length - 1].type === 1) {
+              let cancelledOutMsg = thisChannelOctos[thisChannelOctos.length - 1].id;
+              octoArray.splice(octoArray.findIndex(inst => inst.id === cancelledOutMsg), 1);
           } else {
-            octoArray.push({type: 2, id: msg.id});
+            octoArray.push({type: 2, id: msg.id, chan_id: msg.channel.id});
             setTimeout(matchOcto, octoTimeout, 2, msg);
           }
       } finally { octoMutex.release(); }

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,35 +210,23 @@ syrene.on('message', async (msg: Discord.Message) => {
   if (msg.author.bot) return;
   if (!msg.member) return;
   let content = msg.content.trim();
-  if (content === "<:Octo1:624238806471802902>") {
+  if (content === "<:Octo1:624238806471802902>" || content === "<:Octo2:624238818807119882>") {
     // Use strict equality since we really only want to consider the message body being strictly the emoji.
+      let ty = content==="<:Octo1:624238806471802902>"?1:2;
+      let otherTy = content==="<:Octo1:624238806471802902>"?2:1;
       await octoMutex.lock();
       try {
           let thisChannelOctos = octoArray.filter(inst => inst.chan_id === msg.channel.id);
-          if(thisChannelOctos.length !== 0 && thisChannelOctos[thisChannelOctos.length - 1].type === 2) {
+          if(thisChannelOctos.length !== 0 && thisChannelOctos[thisChannelOctos.length - 1].type === otherTy) {
               //This message is here to match an Octo2; just cancel it out
               let cancelledOutMsg = thisChannelOctos[thisChannelOctos.length - 1].id;
               octoArray.splice(octoArray.findIndex(inst => inst.id === cancelledOutMsg), 1);
           } else {
-            octoArray.push({type: 1, id: msg.id, chan_id: msg.channel.id}); //Remember this message
-            setTimeout(matchOcto, octoTimeout, 1, msg); //Match it later.
+            octoArray.push({type: ty, id: msg.id, chan_id: msg.channel.id}); //Remember this message
+            setTimeout(matchOcto, octoTimeout, ty, msg); //Match it later.
           }
       } finally { octoMutex.release(); }
-  } else if (content === "<:Octo2:624238818807119882>") {
-      //Basically copy paste of above block but with the octo type inverted
-      //Could potentially abstract it out but probs not worth it
-      await octoMutex.lock();
-      try {
-          let thisChannelOctos = octoArray.filter(inst => inst.chan_id === msg.channel.id);
-          if(thisChannelOctos.length !== 0 && thisChannelOctos[thisChannelOctos.length - 1].type === 1) {
-              let cancelledOutMsg = thisChannelOctos[thisChannelOctos.length - 1].id;
-              octoArray.splice(octoArray.findIndex(inst => inst.id === cancelledOutMsg), 1);
-          } else {
-            octoArray.push({type: 2, id: msg.id, chan_id: msg.channel.id});
-            setTimeout(matchOcto, octoTimeout, 2, msg);
-          }
-      } finally { octoMutex.release(); }
-  } 
+  }
 });
 
 (async() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,8 @@ async function checkPublisher(name: string, delayMinutes: number, fn: any) {
 let octoArray = [];
 let octoMutex = new Mutex();
 const octoTimeout = 20000; // 20 seconds
-let octo1Emote = "<:Octo1:624238806471802902>"
-let octo2Emote = "<:Octo2:624238818807119882>"
+const octo1Emote = "<:Octo1:624238806471802902>"
+const octo2Emote = "<:Octo2:624238818807119882>"
 function matchOcto(typeToMatch : number, originalMessage: any) {
     let idOfOriginalMessage = originalMessage.id;
     // No need to check if already matched,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,22 +38,22 @@ async function checkPublisher(name: string, delayMinutes: number, fn: any) {
 let octoArray = [];
 let octoMutex = new Mutex();
 const octoTimeout = 20000; // 20 seconds
-async function matchOcto(typeToMatch : number, originalMessage: any) {
+let octo1Emote = "<:Octo1:624238806471802902>"
+let octo2Emote = "<:Octo2:624238818807119882>"
+function matchOcto(typeToMatch : number, originalMessage: any) {
     let idOfOriginalMessage = originalMessage.id;
-    await octoMutex.lock();
-    try {
-        // Check that it hasn't already been matched (by a user)
-        if(!octoArray.every(inst => inst.id !== idOfOriginalMessage)) {
-            //Remove the message from the array
-            octoArray.splice(octoArray.findIndex(inst => inst.id === idOfOriginalMessage), 1);
-            //Send message to match the octopus.
-            if(typeToMatch == 1) {
-                originalMessage.channel.send(`<:Octo2:624238818807119882>`);
-            } else {
-                originalMessage.channel.send(`<:Octo1:624238806471802902>`);
-            }
-        }
-    } finally { octoMutex.release(); }
+    // No need to check if already matched,
+    // as if it were the timeout would be cleared.
+    
+    //Remove the message from the array
+    octoArray.splice(octoArray.findIndex(inst => inst.id === idOfOriginalMessage), 1);
+    
+    //Send message to match the octopus.
+    if(typeToMatch == 1) {
+        originalMessage.channel.send(octo2Emote);
+    } else {
+        originalMessage.channel.send(octo1Emote);
+    }
 }
 
 client.on('ready', async () => {
@@ -210,22 +210,21 @@ syrene.on('message', async (msg: Discord.Message) => {
   if (msg.author.bot) return;
   if (!msg.member) return;
   let content = msg.content.trim();
-  if (content === "<:Octo1:624238806471802902>" || content === "<:Octo2:624238818807119882>") {
+  if (content === octo1Emote || content === octo2Emote) {
     // Use strict equality since we really only want to consider the message body being strictly the emoji.
-      let ty = content==="<:Octo1:624238806471802902>"?1:2;
-      let otherTy = content==="<:Octo1:624238806471802902>"?2:1;
-      await octoMutex.lock();
-      try {
-          let thisChannelOctos = octoArray.filter(inst => inst.chan_id === msg.channel.id);
-          if(thisChannelOctos.length !== 0 && thisChannelOctos[thisChannelOctos.length - 1].type === otherTy) {
-              //This message is here to match an Octo2; just cancel it out
-              let cancelledOutMsg = thisChannelOctos[thisChannelOctos.length - 1].id;
-              octoArray.splice(octoArray.findIndex(inst => inst.id === cancelledOutMsg), 1);
-          } else {
-            octoArray.push({type: ty, id: msg.id, chan_id: msg.channel.id}); //Remember this message
-            setTimeout(matchOcto, octoTimeout, ty, msg); //Match it later.
-          }
-      } finally { octoMutex.release(); }
+      let ty = content===octo1Emote?1:2;
+      let otherTy = content===octo1Emote?2:1;
+      
+      let thisChannelOctos = octoArray.filter(inst => inst.chan_id === msg.channel.id);
+      if(thisChannelOctos.length !== 0 && thisChannelOctos[thisChannelOctos.length - 1].type === otherTy) {
+        //This message is here to match an Octo2; just cancel it out
+        let toCancel = thisChannelOctos[thisChannelOctos.length - 1];
+        octoArray.splice(octoArray.findIndex(inst => inst.id === toCancel.id), 1);
+        clearTimeout(toCancel.timeout_id);
+      } else {
+      let timeout_id = setTimeout(matchOcto, octoTimeout, ty, msg); //Match it later.
+      octoArray.push({type: ty, id: msg.id, chan_id: msg.channel.id, timeout_id: timeout_id});
+    }
   }
 });
 


### PR DESCRIPTION
If an uneven number of :Octo1: or :Octo2: (as sole messages in chat) are given, the bot will balance after a delay (20 seconds -- to allow for an actual person to react). This feature is available only when booted as Syrene.

- Changes to package-lock were seemingly done by npm automatically while following the setup instructions given

- I did not test this on the actual Dakimakuras discord so I'm unsure if the emoji will show up correctly (as my test bot didn't have Nitro, I was only seeing :Octo1: etc as responses). So please briefly test that prior to merging.